### PR TITLE
Finally

### DIFF
--- a/lib/pry_debugging.rb
+++ b/lib/pry_debugging.rb
@@ -1,4 +1,3 @@
 def plus_two(num)
 	num + 2
-	num
 end


### PR DESCRIPTION
Considered two solutions: (1) removing the "num" variable on the last line of the code so that ruby would not return its value of 3.  (2) placing the word "return" before "num + 2" so that despite "num" being on the following line, ruby would return the expected value of 5 since I have made it explicit what it is I wanted returned.