### PR TITLE
Correct plus_two(num)

### DIFF
--- a/lib/pry_debugging.rb
+++ b/lib/pry_debugging.rb
@@ -1,4 +1,3 @@
 def plus_two(num)
 	num + 2
-	num
 end


### PR DESCRIPTION
Changed plus_two(num) to work correctly and output 5 when num=3.